### PR TITLE
Use bsb in source build for bs-loader as default

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -90,7 +90,16 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.re', '.ml', '.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: [
+      '.re',
+      '.ml',
+      '.web.js',
+      '.mjs',
+      '.js',
+      '.json',
+      '.web.jsx',
+      '.jsx',
+    ],
     alias: {
       // @remove-on-eject-begin
       // Resolve Babel runtime relative to react-scripts.
@@ -217,9 +226,12 @@ module.exports = {
             test: /\.(re|rei|ml|mli)$/,
             use: [
               {
-                loader: require.resolve('bs-loader')
-              }
-            ]
+                loader: require.resolve('bs-loader'),
+                options: {
+                  inSource: true,
+                },
+              },
+            ],
           },
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -96,7 +96,16 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.re', '.ml', '.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: [
+      '.re',
+      '.ml',
+      '.web.js',
+      '.mjs',
+      '.js',
+      '.json',
+      '.web.jsx',
+      '.jsx',
+    ],
     alias: {
       // @remove-on-eject-begin
       // Resolve Babel runtime relative to react-scripts.
@@ -243,9 +252,12 @@ module.exports = {
             test: /\.(re|rei|ml|mli)$/,
             use: [
               {
-                loader: require.resolve('bs-loader')
-              }
-            ]
+                loader: require.resolve('bs-loader'),
+                options: {
+                  inSource: true,
+                },
+              },
+            ],
           },
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.


### PR DESCRIPTION
Fix #69 
It seems like `bs-loader` read `package-specs` from `Reason-Apollo` to load dependencies in `es6` mode too.
By using `bsb` in source build, it seems like solving the issue.